### PR TITLE
Extend rdslogs to consume postgres logs as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: go
 dist: trusty
 
 go:
-  - 1.7.4
+  - 1.9
 
 before_install:
   - sudo apt-get -qq update

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,24 +1,37 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/honeycombio/honeytail/parsers"
+	"github.com/honeycombio/honeytail/parsers/mysql"
+	"github.com/honeycombio/honeytail/parsers/postgresql"
 	"github.com/honeycombio/rdslogs/publisher"
 )
+
+// Fortunately for us, the RDS team has diligently ignored requests to make
+// RDS Postgres's `log_line_prefix` customizable for years
+// (https://forums.aws.amazon.com/thread.jspa?threadID=143460).
+// So we can hard-code this prefix format for Postgres log lines.
+const rdsPostgresLinePrefix = "%t:%r:%u@%d:[%p]:"
 
 // Options contains all the CLI flags
 type Options struct {
 	Region             string `long:"region" description:"AWS region to use" default:"us-east-1"`
 	InstanceIdentifier string `short:"i" long:"identifier" description:"RDS instance identifier"`
-	LogFile            string `short:"f" long:"log_file" description:"RDS log file to retrieve" default:"slowquery/mysql-slowquery.log"`
+	DBType             string `long:"dbtype" description:"RDS database type. Accepted values are mysql and postgresql." default:"mysql"`
+	LogFile            string `short:"f" long:"log_file" description:"RDS log file to retrieve"`
 	Download           bool   `short:"d" long:"download" description:"Download old logs instead of tailing the current log"`
 	DownloadDir        string `long:"download_dir" description:"directory in to which log files are downloaded" default:"./"`
 	NumLines           int64  `long:"num_lines" description:"number of lines to request at a time from AWS. Larger number will be more efficient, smaller number will allow for longer lines" default:"10000"`
@@ -69,8 +82,6 @@ type CLI struct {
 
 	// target to which to send output
 	output publisher.Publisher
-	// memoize the list of log files
-	cachedLogFiles []LogFile
 	// allow changing the time for tests
 	fakeNower Nower
 }
@@ -79,23 +90,32 @@ type CLI struct {
 // spits them out to STDOUT
 func (c *CLI) Stream() error {
 	// make sure we have a valid log file from which to stream
-	logFiles, err := c.getListRDSLogFiles()
+	latestFile, err := c.GetLatestLogFile()
 	if err != nil {
-		return err
-	}
-	if err = validateLogFileMatch(logFiles, c.Options.LogFile); err != nil {
 		return err
 	}
 	// create the chosen output publisher target
 	if c.Options.Output == "stdout" {
 		c.output = &publisher.STDOUTPublisher{}
 	} else {
+		var parser parsers.Parser
+		if c.Options.DBType == "mysql" {
+			parser = &mysql.Parser{}
+			parser.Init(&mysql.Options{})
+		} else if c.Options.DBType == "postgresql" {
+			parser = &postgresql.Parser{}
+			parser.Init(&postgresql.Options{LogLinePrefix: rdsPostgresLinePrefix})
+		} else {
+			return fmt.Errorf("Unknown dbtype value `%s`", c.Options.DBType)
+		}
+
 		pub := &publisher.HoneycombPublisher{
 			Writekey:   c.Options.WriteKey,
 			Dataset:    c.Options.Dataset,
 			APIHost:    c.Options.APIHost,
 			ScrubQuery: c.Options.ScrubQuery,
 			SampleRate: c.Options.SampleRate,
+			Parser:     parser,
 		}
 		defer pub.Close()
 		c.output = pub
@@ -103,7 +123,7 @@ func (c *CLI) Stream() error {
 
 	// forever, download the most recent entries
 	sPos := StreamPos{
-		logFile: LogFile{LogFileName: c.Options.LogFile},
+		logFile: LogFile{LogFileName: latestFile.LogFileName},
 	}
 	for {
 		// check for signal triggered exit
@@ -117,18 +137,18 @@ func (c *CLI) Stream() error {
 		resp, err := c.getRecentEntries(sPos)
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "Throttling: Rate exceeded") {
-				io.WriteString(os.Stderr, fmt.Sprintf("AWS Rate limit hit; sleeping for %d seconds.\n", c.Options.BackoffTimer))
-				time.Sleep(time.Duration(c.Options.BackoffTimer) * time.Second)
+				logrus.Infof("AWS Rate limit hit; sleeping for %d seconds.\n", c.Options.BackoffTimer)
+				c.waitFor(time.Duration(c.Options.BackoffTimer) * time.Second)
 				continue
 			}
 			if strings.HasPrefix(err.Error(), "InvalidParameterValue: This file contains binary data") {
-				io.WriteString(os.Stderr, fmt.Sprintf("binary data at marker %s, skipping 1000 in marker position\n", *sPos.marker))
+				logrus.Infof("binary data at marker %s, skipping 1000 in marker position\n", sPos.marker)
 				// skip over inaccessible data
 				newMarker, err := sPos.Add(1000)
 				if err != nil {
 					return err
 				}
-				sPos.marker = &newMarker
+				sPos.marker = newMarker
 				continue
 			}
 			return err
@@ -138,24 +158,36 @@ func (c *CLI) Stream() error {
 		}
 		// if that's all we've got for now, wait 5 seconds then try again
 		if !*resp.AdditionalDataPending || *resp.Marker == "0" {
-			time.Sleep(5 * time.Second)
+			c.waitFor(5 * time.Second)
 		}
-		oldMarker := resp.Marker
-		sPos.marker = c.getNextMarker(sPos, resp)
-		if c.Options.Debug {
-			if oldMarker == nil {
-				s := "nil"
-				oldMarker = &s
+		oldMarker := sPos.marker
+		newMarker := c.getNextMarker(sPos, resp)
+		if newMarker == oldMarker {
+			newestFile, err := c.GetLatestLogFile()
+			if err != nil {
+				return err
 			}
-			io.WriteString(os.Stderr, fmt.Sprintf("%s got %s as next marker, using %s\n",
-				time.Now().Format("Jan 02 15:04"), *oldMarker, *sPos.marker))
+			if newestFile.LogFileName != sPos.logFile.LogFileName {
+				logrus.WithFields(logrus.Fields{
+					"prevMarker": oldMarker,
+					"newMarker":  newMarker,
+					"oldFile":    sPos.logFile.LogFileName,
+					"newFile":    newestFile.LogFileName}).Debug("Found newer file")
+				sPos = StreamPos{logFile: LogFile{LogFileName: newestFile.LogFileName}}
+			}
+		} else {
+			sPos.marker = newMarker
+			logrus.WithFields(logrus.Fields{
+				"prevMarker": oldMarker,
+				"newMarker":  newMarker,
+				"file":       sPos.logFile.LogFileName}).Debug("Got new marker")
 		}
 	}
 }
 
 // getNextMarker takes in to account the current and next reported markers and
 // decides whether to believe the resp.Marker or calculate its own next marker.
-func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOutput) *string {
+func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOutput) string {
 	// if resp is nil, we're up a creek and should return sPos' marker, but at
 	// least we shouldn't try and dereference it and panic.
 	if resp == nil {
@@ -167,7 +199,7 @@ func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOu
 	// when we get to the end of a log segment, the marker in resp is "0".
 	// if it's not "0", we should trust it's correct and use it.
 	if *resp.Marker != "0" {
-		return resp.Marker
+		return *resp.Marker
 	}
 	// ok, we've hit the end of a segment, but did we get any data? If we got
 	// data, then it's not really the end of the segment and we should calculate a
@@ -176,9 +208,9 @@ func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOu
 		newMarkerStr, err := sPos.Add(len(*resp.LogFileData))
 		if err != nil {
 			fmt.Printf("failed to get next marker. Reverting to no marker. %s\n", err)
-			return nil
+			return "0"
 		}
-		return &newMarkerStr
+		return newMarkerStr
 	}
 	// we hit the end of a segment but we didn't get any data. we should try again
 	// during the 00-05 minutes past the hour time, and roll over once we get to 6
@@ -191,7 +223,7 @@ func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOu
 	}
 	curMin, _ := strconv.Atoi(now.Format("04"))
 	if curMin > 5 {
-		return resp.Marker
+		return *resp.Marker
 	}
 	// let's try again from where we did the last time.
 	return sPos.marker
@@ -200,12 +232,12 @@ func (c *CLI) getNextMarker(sPos StreamPos, resp *rds.DownloadDBLogFilePortionOu
 // StreamPos represents a log file and marker combination
 type StreamPos struct {
 	logFile LogFile
-	marker  *string
+	marker  string
 }
 
 // Add returns a new marker string that is the current marker + dataLen offset
 func (s *StreamPos) Add(dataLen int) (string, error) {
-	splitMarker := strings.Split(*s.marker, ":")
+	splitMarker := strings.Split(s.marker, ":")
 	if len(splitMarker) != 2 {
 		// something's wrong. marker should have been #:#
 		// TODO provide a better value
@@ -227,8 +259,8 @@ func (c *CLI) getRecentEntries(sPos StreamPos) (*rds.DownloadDBLogFilePortionOut
 		NumberOfLines:        aws.Int64(c.Options.NumLines),
 	}
 	// if we have a marker, download from there. otherwise get the most recent line
-	if sPos.marker != nil {
-		params.Marker = sPos.marker
+	if sPos.marker != "" {
+		params.Marker = &sPos.marker
 	} else {
 		params.NumberOfLines = aws.Int64(1)
 	}
@@ -273,7 +305,7 @@ func (l *LogFile) String() string {
 
 // DownloadLogFiles returns a new copy of the logFile list because it mutates the contents.
 func (c *CLI) DownloadLogFiles(logFiles []LogFile) ([]LogFile, error) {
-	fmt.Fprintf(os.Stderr, "Downloading log files to %s\n", c.Options.DownloadDir)
+	logrus.Infof("Downloading log files to %s\n", c.Options.DownloadDir)
 	downloadedLogFiles := make([]LogFile, 0, len(logFiles))
 	for i := range logFiles {
 		// returned logFile has a modified Path
@@ -330,13 +362,6 @@ func (c *CLI) downloadFile(logFile LogFile) (LogFile, error) {
 	return logFile, nil
 }
 
-// Equal returns true if the timestamps and sizes are equal, even if the names
-// are not. As AWS rotates log files, it changes the names every hour.
-func (l *LogFile) Equal(candidate LogFile) bool {
-	return l.LastWritten == candidate.LastWritten &&
-		l.Size == candidate.Size
-}
-
 // GetLogFiles returns a list of all log files based on the Options.LogFile pattern
 func (c *CLI) GetLogFiles() ([]LogFile, error) {
 	// get a list of all log files.
@@ -347,46 +372,45 @@ func (c *CLI) GetLogFiles() ([]LogFile, error) {
 		return nil, err
 	}
 
-	if err = validateLogFileMatch(logFiles, c.Options.LogFile); err != nil {
-		return nil, err
-	}
-
 	var matchingLogFiles []LogFile
 	for _, lf := range logFiles {
-		if lf.LogFileName == c.Options.LogFile ||
-			strings.HasPrefix(lf.LogFileName, c.Options.LogFile) {
+		if strings.HasPrefix(lf.LogFileName, c.Options.LogFile) {
 			matchingLogFiles = append(matchingLogFiles, lf)
 		}
 	}
 	// matchingLogFiles now contains a list of eligible log files,
 	// eg slow.log, slow.log.1, slow.log.2, etc.
 
+	if len(matchingLogFiles) == 0 {
+		errParts := []string{"No log file with the given prefix found. Available log files:"}
+
+		for _, lf := range logFiles {
+			errParts = append(errParts, fmt.Sprint("\t", lf.String()))
+		}
+		return nil, fmt.Errorf(strings.Join(errParts, "\n"))
+
+	}
+
 	return matchingLogFiles, nil
 }
 
-func validateLogFileMatch(logFiles []LogFile, toMatch string) error {
-	for _, lf := range logFiles {
-		if lf.LogFileName == toMatch {
-			return nil
-		}
+func (c *CLI) GetLatestLogFile() (LogFile, error) {
+	logFiles, err := c.GetLogFiles()
+	if err != nil {
+		return LogFile{}, err
 	}
-	errParts := []string{"No log file with the given name found. Available log files:"}
 
-	// TODO sort log files by timestamp
-	for _, lf := range logFiles {
-		errParts = append(errParts, fmt.Sprint("\t", lf.String()))
+	if len(logFiles) == 0 {
+		return LogFile{}, errors.New("No log files found")
 	}
-	errParts = append(errParts, "Please specify one of these log files with the --log_file flag")
-	return fmt.Errorf(strings.Join(errParts, "\n"))
+
+	sort.SliceStable(logFiles, func(i, j int) bool { return logFiles[i].LastWritten < logFiles[j].LastWritten })
+	return logFiles[len(logFiles)-1], nil
 }
 
-// gets a list of all avaialable RDS log files for an instance
+// gets a list of all available RDS log files for an instance, sorted by
+// LastWritten timestamp
 func (c *CLI) getListRDSLogFiles() ([]LogFile, error) {
-	if c.cachedLogFiles != nil {
-		// don't hit AWS twice for the same info
-		return c.cachedLogFiles, nil
-	}
-
 	var output *rds.DescribeDBLogFilesOutput
 	var err error
 	var logFiles []LogFile
@@ -397,13 +421,11 @@ func (c *CLI) getListRDSLogFiles() ([]LogFile, error) {
 				DBInstanceIdentifier: &c.Options.InstanceIdentifier,
 			})
 			logFiles = make([]LogFile, 0, len(output.DescribeDBLogFiles))
-			fmt.Print("Downloading.")
 		} else {
 			output, err = c.RDS.DescribeDBLogFiles(&rds.DescribeDBLogFilesInput{
 				DBInstanceIdentifier: &c.Options.InstanceIdentifier,
-				Marker: output.Marker,
+				Marker:               output.Marker,
 			})
-			fmt.Print(".")
 		}
 		if err != nil {
 			return nil, err
@@ -419,12 +441,10 @@ func (c *CLI) getListRDSLogFiles() ([]LogFile, error) {
 			})
 		}
 		if output.Marker == nil {
-			fmt.Print("\n")
 			break
 		}
 	}
 
-	c.cachedLogFiles = logFiles
 	return logFiles, nil
 }
 
@@ -475,6 +495,15 @@ func (c *CLI) getListRDSInstances() ([]string, error) {
 		instances[i] = *instance.DBInstanceIdentifier
 	}
 	return instances, nil
+}
+
+func (c *CLI) waitFor(d time.Duration) {
+	select {
+	case <-c.Abort:
+		return
+	case <-time.After(d):
+		return
+	}
 }
 
 // Nower interface abstracts time for testing

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -23,7 +23,7 @@ func TestGetNextMarker(t *testing.T) {
 	startingPos := "12:1234"
 	streamPos := StreamPos{
 		logFile: LogFile{},
-		marker:  &startingPos,
+		marker:  startingPos,
 	}
 	resp := rds.DownloadDBLogFilePortionOutput{}
 	respPos := "12:2345"
@@ -32,8 +32,8 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != respPos {
-		t.Errorf("response marker %s expected, got %s", respPos, *nextMarker)
+	if nextMarker != respPos {
+		t.Errorf("response marker %s expected, got %s", respPos, nextMarker)
 	}
 	// next position unchanged but legit
 	respPos = "12:1234"
@@ -42,8 +42,8 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != respPos {
-		t.Errorf("response marker %s expected, got %s", respPos, *nextMarker)
+	if nextMarker != respPos {
+		t.Errorf("response marker %s expected, got %s", respPos, nextMarker)
 	}
 	// next position 0 and no data, not in :00-:05 time range, expect resp
 	respPos = "0"
@@ -52,8 +52,8 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != respPos {
-		t.Errorf("response marker %s expected, got %s", respPos, *nextMarker)
+	if nextMarker != respPos {
+		t.Errorf("response marker %s expected, got %s", respPos, nextMarker)
 	}
 	// next position 0 and no data, in :00-:05 time range, expect startingPos
 	c.fakeNower.(*FakeNower).t, _ = time.Parse(time.RFC3339, "2010-06-21T15:03:05Z")
@@ -63,8 +63,8 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != startingPos {
-		t.Errorf("response marker %s expected, got %s", startingPos, *nextMarker)
+	if nextMarker != startingPos {
+		t.Errorf("response marker %s expected, got %s", startingPos, nextMarker)
 	}
 	// next position 0 and have data, not in :00-:05 time range, expect start+len
 	respContent := "this is a slow query log entry, really."
@@ -76,8 +76,8 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != expectedMarker {
-		t.Errorf("response marker %s expected, got %s", expectedMarker, *nextMarker)
+	if nextMarker != expectedMarker {
+		t.Errorf("response marker %s expected, got %s", expectedMarker, nextMarker)
 	}
 	// next position 0 and have data, in :00-:05 time range, expect start+len
 	c.fakeNower.(*FakeNower).t, _ = time.Parse(time.RFC3339, "2010-06-21T15:03:05Z")
@@ -87,15 +87,15 @@ func TestGetNextMarker(t *testing.T) {
 	if resp.Marker == nil {
 		t.Error("unexpected resp marker nil")
 	}
-	if *nextMarker != expectedMarker {
-		t.Errorf("response marker %s expected, got %s", expectedMarker, *nextMarker)
+	if nextMarker != expectedMarker {
+		t.Errorf("response marker %s expected, got %s", expectedMarker, nextMarker)
 	}
 }
 
 func TestStreamAdd(t *testing.T) {
 	startingPos := "12:1234"
 	streamPos := StreamPos{
-		marker: &startingPos,
+		marker: startingPos,
 	}
 	lenToAdd := 60
 	expectedPos := "12:1294"
@@ -107,50 +107,4 @@ func TestStreamAdd(t *testing.T) {
 		t.Errorf("position %s added to length %d got %s, expected %s", startingPos,
 			lenToAdd, sumPos, expectedPos)
 	}
-}
-
-func TestLogFileEqual(t *testing.T) {
-	// base
-	lfA := LogFile{
-		Size:        45,
-		LogFileName: "foo",
-		LastWritten: 67,
-	}
-	// same as A, despite different name
-	lfB := LogFile{
-		Size:        45,
-		LogFileName: "bar",
-		LastWritten: 67,
-	}
-	// diff LastWritten
-	lfC := LogFile{
-		Size:        45,
-		LogFileName: "bar",
-		LastWritten: 89,
-	}
-	// diff Size
-	lfD := LogFile{
-		Size:        56,
-		LogFileName: "bar",
-		LastWritten: 67,
-	}
-	// diff Size and LastWritten
-	lfE := LogFile{
-		Size:        56,
-		LogFileName: "bar",
-		LastWritten: 89,
-	}
-	if !lfA.Equal(lfB) {
-		t.Errorf("expected lfA == lfB. (%+v, %+v)", lfA, lfB)
-	}
-	if lfA.Equal(lfC) {
-		t.Errorf("expected lfA != lfC. (%+v, %+v)", lfA, lfC)
-	}
-	if lfA.Equal(lfD) {
-		t.Errorf("expected lfA != lfD. (%+v, %+v)", lfA, lfD)
-	}
-	if lfA.Equal(lfE) {
-		t.Errorf("expected lfA != lfE. (%+v, %+v)", lfA, lfE)
-	}
-
 }


### PR DESCRIPTION
This is a bit hairier than one would wish. In RDS, MySQL query logs look like
this:

```
slowquery/mysql-slowquery.log
slowquery/mysql-slowquery.log.0
slowquery/mysql-slowquery.log.1
```

On the other hand, Postgres logs all look like this:

```
error/postgresql.log.2017-11-12-02
error/postgresql.log.2017-11-12-03
error/postgresql.log.2017-11-12-04
```

This means that we can't take the configured log file name verbatim and
download it. Instead, we use the following strategy:

1. Look for all log files that have `Options.LogFile` as a prefix.
2. Tail the newest one until its end.
3. If we get to the end of the file, look to see if there's a newer file.
4. If there is, switch over to tailing that one from the beginning.

This is a bit messy, but works equally well for both postgres and mysql.

This patch includes a bit of related cleanup:
- switch type of `StreamPos.marker` from string pointer to string for sanity
- make it so that Ctrl-C interrupts the process even if it's sleeping
- remove a bit of dead and debug code.