### PR TITLE
Build docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y build-essential rpm
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - gem install fpm
 
 script:
@@ -23,6 +24,10 @@ after_success:
   - $GOPATH/bin/rdslogs --write_default_config > ./rdslogs.conf
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  - docker build -t "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" .
+  - docker push "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}"
+
 
 addons:
     artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.9-alpine
+
+COPY . /go/src/github.com/honeycombio/rdslogs
+WORKDIR /go/src/github.com/honeycombio/rdslogs
+RUN apk update && apk add git
+RUN go get ./...
+RUN go install ./...
+
+FROM golang:1.9-alpine
+COPY --from=0 /go/bin/rdslogs /rdslogs
+ENTRYPOINT ["/rdslogs"]


### PR DESCRIPTION
Fixes #11.

This is pretty minimal -- literally just puts the binary in a container. Users
will have to supply their own command-line arguments when running
the container, e.g.,
`docker run honeycombio/rdslogs:1.22 --writekey $WRITEKEY --identifier my-database ...`
but I think that's okay.