### PR TITLE
Tag newly built docker image with latest too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ after_success:
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   - docker build -t "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" .
-  - docker tag "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" honeycomb.io/rdslogs:latest
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then docker tag "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" honeycomb.io/rdslogs:latest; fi
   - docker push honeycombio/rdslogs
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ after_success:
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   - docker build -t "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" .
-  - docker push "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}"
+  - docker tag "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" honeycomb.io/rdslogs:latest
+  - docker push honeycombio/rdslogs
 
 
 addons:


### PR DESCRIPTION
We (@journera) are looking into getting this setup in our environment to start shipping our RDS queries to Honeycomb.

The path I'm currently going down to do this is taking the docker image created by travis as a base, and adding our extras for getting the configuration from our environment.

This change would start tagging the current build as `latest` as well as the current build number. This would help me because we can automate our CI system off of a docker image's tag changing, but not off of a new tag being pushed.