### PR TITLE
Add ExtraFields option to allow someone to add arbitrary extra fields to data sent to Honeycomb

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ type Options struct {
 	APIHost            string            `long:"api_host" description:"Hostname for the Honeycomb API server" default:"https://api.honeycomb.io/"`
 	ScrubQuery         bool              `long:"scrub_query" description:"Replaces the query field with a one-way hash of the contents"`
 	SampleRate         int               `long:"sample_rate" description:"Only send 1 / N log lines" default:"1"`
-	ExtraFields        map[string]string `short:"e" long:"extra-field" description:"Extra fields to send in request, in the style of \"field:value\""`
+	AddFields          map[string]string `short:"a" long:"add_field" description:"Extra fields to send in request, in the style of \"field:value\""`
 
 	Version            bool   `short:"v" long:"version" description:"Output the current version and exit"`
 	ConfigFile         string `short:"c" long:"config" description:"config file" no-ini:"true"`
@@ -114,13 +114,13 @@ func (c *CLI) Stream() error {
 		}
 
 		pub := &publisher.HoneycombPublisher{
-			Writekey:    c.Options.WriteKey,
-			Dataset:     c.Options.Dataset,
-			APIHost:     c.Options.APIHost,
-			ScrubQuery:  c.Options.ScrubQuery,
-			SampleRate:  c.Options.SampleRate,
-			ExtraFields: c.Options.ExtraFields,
-			Parser:      parser,
+			Writekey:   c.Options.WriteKey,
+			Dataset:    c.Options.Dataset,
+			APIHost:    c.Options.APIHost,
+			ScrubQuery: c.Options.ScrubQuery,
+			SampleRate: c.Options.SampleRate,
+			AddFields:  c.Options.AddFields,
+			Parser:     parser,
 		}
 		defer pub.Close()
 		c.output = pub

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -31,20 +31,21 @@ const DBTypeMySQL = "mysql"
 
 // Options contains all the CLI flags
 type Options struct {
-	Region             string `long:"region" description:"AWS region to use" default:"us-east-1"`
-	InstanceIdentifier string `short:"i" long:"identifier" description:"RDS instance identifier"`
-	DBType             string `long:"dbtype" description:"RDS database type. Accepted values are mysql and postgresql." default:"mysql"`
-	LogFile            string `short:"f" long:"log_file" description:"RDS log file to retrieve"`
-	Download           bool   `short:"d" long:"download" description:"Download old logs instead of tailing the current log"`
-	DownloadDir        string `long:"download_dir" description:"directory in to which log files are downloaded" default:"./"`
-	NumLines           int64  `long:"num_lines" description:"number of lines to request at a time from AWS. Larger number will be more efficient, smaller number will allow for longer lines" default:"10000"`
-	BackoffTimer       int64  `long:"backoff_timer" description:"how many seconds to pause when rate limited by AWS." default:"5"`
-	Output             string `short:"o" long:"output" description:"output for the logs: stdout or honeycomb" default:"stdout"`
-	WriteKey           string `long:"writekey" description:"Team write key, when output is honeycomb"`
-	Dataset            string `long:"dataset" description:"Name of the dataset, when output is honeycomb"`
-	APIHost            string `long:"api_host" description:"Hostname for the Honeycomb API server" default:"https://api.honeycomb.io/"`
-	ScrubQuery         bool   `long:"scrub_query" description:"Replaces the query field with a one-way hash of the contents"`
-	SampleRate         int    `long:"sample_rate" description:"Only send 1 / N log lines" default:"1"`
+	Region             string            `long:"region" description:"AWS region to use" default:"us-east-1"`
+	InstanceIdentifier string            `short:"i" long:"identifier" description:"RDS instance identifier"`
+	DBType             string            `long:"dbtype" description:"RDS database type. Accepted values are mysql and postgresql." default:"mysql"`
+	LogFile            string            `short:"f" long:"log_file" description:"RDS log file to retrieve"`
+	Download           bool              `short:"d" long:"download" description:"Download old logs instead of tailing the current log"`
+	DownloadDir        string            `long:"download_dir" description:"directory in to which log files are downloaded" default:"./"`
+	NumLines           int64             `long:"num_lines" description:"number of lines to request at a time from AWS. Larger number will be more efficient, smaller number will allow for longer lines" default:"10000"`
+	BackoffTimer       int64             `long:"backoff_timer" description:"how many seconds to pause when rate limited by AWS." default:"5"`
+	Output             string            `short:"o" long:"output" description:"output for the logs: stdout or honeycomb" default:"stdout"`
+	WriteKey           string            `long:"writekey" description:"Team write key, when output is honeycomb"`
+	Dataset            string            `long:"dataset" description:"Name of the dataset, when output is honeycomb"`
+	APIHost            string            `long:"api_host" description:"Hostname for the Honeycomb API server" default:"https://api.honeycomb.io/"`
+	ScrubQuery         bool              `long:"scrub_query" description:"Replaces the query field with a one-way hash of the contents"`
+	SampleRate         int               `long:"sample_rate" description:"Only send 1 / N log lines" default:"1"`
+	ExtraFields        map[string]string `short:"e" long:"extra-field" description:"Extra fields to send in request, in the style of \"field:value\""`
 
 	Version            bool   `short:"v" long:"version" description:"Output the current version and exit"`
 	ConfigFile         string `short:"c" long:"config" description:"config file" no-ini:"true"`
@@ -113,12 +114,13 @@ func (c *CLI) Stream() error {
 		}
 
 		pub := &publisher.HoneycombPublisher{
-			Writekey:   c.Options.WriteKey,
-			Dataset:    c.Options.Dataset,
-			APIHost:    c.Options.APIHost,
-			ScrubQuery: c.Options.ScrubQuery,
-			SampleRate: c.Options.SampleRate,
-			Parser:     parser,
+			Writekey:    c.Options.WriteKey,
+			Dataset:     c.Options.Dataset,
+			APIHost:     c.Options.APIHost,
+			ScrubQuery:  c.Options.ScrubQuery,
+			SampleRate:  c.Options.SampleRate,
+			ExtraFields: c.Options.ExtraFields,
+			Parser:      parser,
 		}
 		defer pub.Close()
 		c.output = pub

--- a/main.go
+++ b/main.go
@@ -113,12 +113,12 @@ func parseFlags() (*cli.Options, error) {
 
 	// parse flags and check for extra command line args
 	if extraArgs, err := flagParser.Parse(); err != nil || len(extraArgs) != 0 {
-		if err.(*flag.Error).Type == flag.ErrHelp {
-			// user specified --help
-			os.Exit(0)
-		}
-		fmt.Fprintln(os.Stderr, "Failed to parse the command line. Run with --help for more info")
 		if err != nil {
+			if err.(*flag.Error).Type == flag.ErrHelp {
+				// user specified --help
+				os.Exit(0)
+			}
+			fmt.Fprintln(os.Stderr, "Failed to parse the command line. Run with --help for more info")
 			return nil, err
 		}
 		return nil, fmt.Errorf("Unexpected extra arguments: %s\n", strings.Join(extraArgs, " "))

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -29,7 +29,7 @@ type HoneycombPublisher struct {
 	ScrubQuery   bool
 	SampleRate   int
 	Parser       parsers.Parser
-	ExtraFields  map[string]string
+	AddFields    map[string]string
 	initialized  bool
 	lines        chan string
 	eventsToSend chan event.Event
@@ -67,10 +67,10 @@ func (h *HoneycombPublisher) Write(chunk string) {
 
 				// add extra fields first so they don't override anything parsed
 				// in the log file
-				if err := libhEv.Add(h.ExtraFields); err != nil {
+				if err := libhEv.Add(h.AddFields); err != nil {
 					logrus.WithFields(logrus.Fields{
-						"extra_fields": h.ExtraFields,
-						"error":        err,
+						"add_fields": h.AddFields,
+						"error":      err,
 					}).Error("Unexpected error adding extra fields data to libhoney event")
 				}
 

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -29,6 +29,7 @@ type HoneycombPublisher struct {
 	ScrubQuery   bool
 	SampleRate   int
 	Parser       parsers.Parser
+	ExtraFields  map[string]string
 	initialized  bool
 	lines        chan string
 	eventsToSend chan event.Event
@@ -63,6 +64,16 @@ func (h *HoneycombPublisher) Write(chunk string) {
 				}
 				libhEv := libhoney.NewEvent()
 				libhEv.Timestamp = ev.Timestamp
+
+				// add extra fields first so they don't override anything parsed
+				// in the log file
+				if err := libhEv.Add(h.ExtraFields); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"extra_fields": h.ExtraFields,
+						"error":        err,
+					}).Error("Unexpected error adding extra fields data to libhoney event")
+				}
+
 				if err := libhEv.Add(ev.Data); err != nil {
 					logrus.WithFields(logrus.Fields{
 						"event": ev,


### PR DESCRIPTION
Problem:
As written, the only way to send logs from multiple databases to honeycomb you'd need to have a separate dataset per database.

Solution:
Allow people running rdslogs to send arbitrary tags along with the parsed data.

Tags in mind would be things like `aws_region`, `database_name`, or any other identifiers a user may want to add.

This would be invoked with `-e key:value` or `--extra-field key:value`.

----

Also includes a fix to prevent the program from panicing when extra fields are added (ex `rdslogs foo` previously caused a panic).

``` bash
$ rdslogs-original foo
panic: interface conversion: error is nil, not *flags.Error

$ rdslogs foo
2017/12/18 16:18:21 Unexpected extra arguments: foo
```