### PR TITLE
Add documentation/sample configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,29 @@ Usage:
 rdslogs streams a log file from Amazon RDS and prints it to STDOUT or sends it
 up to Honeycomb.io.
 
+## AWS Requirements
+
 AWS credentials are required and can be provided via IAM roles, AWS shared
 config (~/.aws/config), AWS shared credentials (~/.aws/credentials), or
 the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+Below is the minimal IAM policy needed by RDSLogs.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Effect": "Allow",
+        "Action": [
+            "rds:DescribeDBInstances",
+            "rds:DescribeDBLogFiles",
+            "rds:DownloadDBLogFilePortion"
+        ],
+        "Resource": "*"
+    }
+  ]
+}
+```
 
 Passing --download triggers Download Mode, in which rdslogs will download the
 specified logs to the directory specified by --download_dir. Logs are specified

--- a/kubernetes/rdslogs.yml
+++ b/kubernetes/rdslogs.yml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: honeycomb-rdslogs
+spec:
+  selector:
+    matchLabels:
+      app: rdslogs
+  # RDSLogs should run as a singleton.
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rdslogs
+    spec:
+      containers:
+      - name: honeycomb-rdslogs
+        image: honeycombio/rdslogs:latest
+        command: ["/rdslogs"]
+        args:
+          - --region=us-east-1
+          # set this to your RDS instance name
+          - --identifier=CHANGME
+          - --writekey=$(WRITE_KEY)
+          - --dataset=rds
+          - --output=honeycomb
+        resources:
+          requests:
+            # Depending on your sample rate and your RDS workload, you may
+            # need to adjust this up or down
+            cpu: 250m
+            memory: 100Mi
+        env:
+        - name: WRITE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: honeycomb-write-key
+              key: write_key
+        - name: AWS_DEFAULT_REGION
+          value: us-east-1
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: honeycomb-rdslogs-svc-user
+              key: aws_access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: honeycomb-rdslogs-svc-user
+              key: aws_secret_access_key
+# The secret specs below are optional if you already have AWS and Honeycomb
+# secrets configured in k8s
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: honeycomb-rdslogs-svc-user
+type: Opaque
+data:
+  # kubernetes expects base64-encoded secrets
+  aws_access_key_id: CHANGEME
+  aws_secret_access_key: CHANGEME
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: honeycomb-write-key
+type: Opaque
+data:
+  write_key: CHANGEME
+...

--- a/terraform/rdslogs.tf
+++ b/terraform/rdslogs.tf
@@ -1,0 +1,31 @@
+# This terraform configuration describes the minimum AWS requirements
+# for RDSLogs
+resource aws_iam_user "honeycomb-rdslogs-svc-user" {
+  name = "honeycomb-rdslogs-svc-user"
+}
+
+resource "aws_iam_policy" "honeycomb-rdslogs-policy" {
+  name = "honeycomb-rdslogs-policy"
+  description = "minimal policy for honeycomb RDSLogs"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Effect": "Allow",
+        "Action": [
+            "rds:DescribeDBInstances",
+            "rds:DescribeDBLogFiles",
+            "rds:DownloadDBLogFilePortion"
+        ],
+        "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "honeycomb-rdslogs-user-policy" {
+    user       = "${aws_iam_user.honeycomb-rdslogs-svc-user.name}"
+    policy_arn = "${aws_iam_policy.honeycomb-rdslogs-policy.arn}"
+}


### PR DESCRIPTION
Addresses https://github.com/honeycombio/rdslogs/issues/13 by documenting the minimum IAM policy needed. I also decided to check in a sample terraform config for setting up IAM, and a kubernetes config for running rdslogs in k8s.