### PR TITLE
Fix duplicate events during audit log rotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_success:
   - $GOPATH/bin/rdslogs --write_default_config > ./rdslogs.conf
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
   - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
-  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  - echo -n "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
   - docker build -t "honeycombio/rdslogs:1.${TRAVIS_BUILD_NUMBER}" .
   - docker push honeycombio/rdslogs
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -188,7 +188,7 @@ func (c *CLI) Stream() error {
 
 			// If we reset our marker, asked for logs, and got an empty marker back,
 			// we don't have anything to do but wait
-			if sPos.marker == "0" && *resp.Marker == "" {
+			if sPos.marker == "0" && (resp.Marker != nil && *resp.Marker == "") {
 				c.waitFor(time.Second * 5)
 				continue
 			}
@@ -201,7 +201,7 @@ func (c *CLI) Stream() error {
 			// for logfile data
 			// In either scenario, we need to check for a new file. When we're sure there's a new file,
 			// reset the marker
-			if (sPos.marker == *resp.Marker && resp.LogFileData != nil) ||
+			if (resp.Marker != nil && resp.LogFileData != nil && sPos.marker == *resp.Marker) ||
 				!*resp.AdditionalDataPending && resp.LogFileData == nil {
 				newestFile, err := c.GetLatestLogFile()
 				if err != nil {
@@ -244,7 +244,7 @@ func (c *CLI) Stream() error {
 			}
 		}
 
-		if !*resp.AdditionalDataPending || *resp.Marker == "0" {
+		if !*resp.AdditionalDataPending || (resp.Marker != nil && *resp.Marker == "0") {
 			if c.Options.DBType == DBTypePostgreSQL {
 				// If that's all we've got for now, see if there's a newer file to
 				// start tailing. This logic is only relevant for postgres: the


### PR DESCRIPTION
Found a bug that occurs when the audit log is rotated. Basically, until the first 10000 lines (or first 1MB, whichever happens first) are written to the new log, we would fail to update the marker. This is because before that first 10000 lines, AdditionalDataPending is always false, which would send us down this path:

```
// If the marker is already at 0 we don't have anything to do
if sPos.marker == "0" {
    c.waitFor(time.Second * 5)
    continue
}
```

This would bypass the call to `getNextMarker` and we would consume the same lines over and over until 10000 lines were reached, making AdditionalDataPending true. On our relatively busy production mysql, this could take as long as 35 minutes.

```
time="2018-04-25T16:09:57Z" level=info msg="newest file is a rotated file, we appear to be mid-rotation" expectedFile=audit/server_audit.log newestFile=audit/server_audit.log.1
time="2018-04-25T16:10:02Z" level=debug msg="last marker offset exceeds newest file size, resetting marker to 0" currentOffset=99996906 newFileSize=40522
time="2018-04-25T16:45:04Z" level=debug msg="Got new marker" file=audit/server_audit.log newMarker="17:893320" prevMarker=0
```