### PR TITLE
Catch DBLogFileNotFoundFault errors and retry

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -175,6 +175,12 @@ func (c *CLI) Stream() error {
 				sPos.marker = newMarker
 				continue
 			}
+			if strings.HasPrefix(err.Error(), "DBLogFileNotFoundFault") {
+				logrus.WithError(err).
+					Warn("log does not appear to exist (rotation ongoing?) - waiting and retrying")
+				c.waitFor(time.Second * 5)
+				continue
+			}
 			return err
 		}
 		if resp.LogFileData != nil {


### PR DESCRIPTION
When log rotations happen in RDS, the log file can go completely missing in the API, resulting in a DBLogFileNotFoundFault error. We shouldn't exit entirely when this occurs, but we should warn that it's happening. If it's a rotation, waiting a few seconds and retrying should be sufficient.