### PR TITLE
Add AssumeRole with ExternalID Support

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -52,6 +52,8 @@ type Options struct {
 	SampleRate         int               `long:"sample_rate" description:"Only send 1 / N log lines" default:"1"`
 	AddFields          map[string]string `short:"a" long:"add_field" description:"Extra fields to send in request, in the style of \"field:value\""`
 	NumParsers         int               `long:"num_parsers" default:"4" description:"Number of parsers to spin up. Currently only supported for the mysql parser."`
+	AssumeRoleArn      string            `long:"assumerolearn" description:"AWS Role to assume"`
+	ExternalID         string            `long:"externalid" description:"ExternalID for AssumeRoleArn"`
 
 	Version            bool   `short:"v" long:"version" description:"Output the current version and exit"`
 	ConfigFile         string `short:"c" long:"config" description:"config file" no-ini:"true"`

--- a/main.go
+++ b/main.go
@@ -49,8 +49,6 @@ func main() {
 	}()
 
 	if options.AssumeRoleArn != "" {
-		fmt.Fprintln(os.Stderr, "AssumeRoleArn set, using it")
-		fmt.Fprintln(os.Stderr, options.AssumeRoleArn)
 		sess := session.Must(session.NewSession())
 		creds = stscreds.NewCredentials(sess, options.AssumeRoleArn, func(p *stscreds.AssumeRoleProvider) {
 			if options.ExternalID != "" {

--- a/main.go
+++ b/main.go
@@ -49,13 +49,14 @@ func main() {
 	}()
 
 	if options.AssumeRoleArn != "" {
+		fmt.Fprintln(os.Stderr, "AssumeRoleArn set, using it")
+		fmt.Fprintln(os.Stderr, options.AssumeRoleArn)
 		sess := session.Must(session.NewSession())
-		creds := stscreds.NewCredentials(sess, options.AssumeRoleArn, func(p *stscreds.AssumeRoleProvider) {
+		creds = stscreds.NewCredentials(sess, options.AssumeRoleArn, func(p *stscreds.AssumeRoleProvider) {
 			if options.ExternalID != "" {
 				p.ExternalID = aws.String(options.ExternalID)
 			}
 		})
-		_ = creds
 	}
 
 	c := &cli.CLI{


### PR DESCRIPTION
I wanted to be able to assumerole to access another aws account and this basically adds the support for this. I don't really have any GO experience but this seems to work for me.

rdslogs --region eu-west-1 --assumerolearn arn:aws:iam::012345678900:role/RoleNameHere --externalid SecretHere -i identifier