### PR TITLE
Add CircleCI config to build, test and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,19 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.0
+  buildevents: honeycombio/buildevents@0.2.8
+  aws-cli: circleci/aws-cli@2.0.3
+
+executors:
+  linuxgo:
+    docker:
+      - image: cimg/go:1.18
+        environment:
+          GO111MODULE: "on"
+  pkg:
+    ## executor with ruby for installing fpm and building packages
+    docker:
+      - image: cimg/ruby:latest
 
 commands:
   go-build:
@@ -9,92 +21,175 @@ commands:
       os:
         description: Target operating system
         type: enum
-        enum: [ "linux", "darwin" ]
+        enum: ["linux", "darwin"]
         default: "linux"
       arch:
         description: Target architecture
         type: enum
-        enum: [ "amd64", "arm64" ]
+        enum: ["386", "amd64", "arm64"]
         default: "amd64"
-      dir:
-        description: Output directory
-        type: string
-        default: "~/artifacts"
     steps:
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
-          go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
-          -o << parameters.dir >>/rdslogs-<< parameters.os >>-<< parameters.arch >> \
+          CGO_ENABLED=0 \
+          buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_build -- \
+          go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
+          -o $GOPATH/bin/rdslogs-<< parameters.os >>-<< parameters.arch >> \
           ./...
 
 jobs:
-  test:
-    docker:
-      - image: cimg/go:1.18
+  setup:
+    executor: linuxgo
     steps:
-      - checkout
-      - go/load-cache
-      - go/test:
-          race: true
-          verbose: true
-          covermode: atomic
-      - go/save-cache
-
-  build:
-    docker:
-      - image: cimg/go:1.18
-    steps:
-      - checkout
-      - go/load-cache
-      - run: mkdir -p ~/artifacts
-      - go-build:
-          os: linux
-          arch: amd64
-      - go-build:
-          os: linux
-          arch: arm64
-      - go-build:
-          os: darwin
-          arch: amd64
+      - buildevents/start_trace
+      - run: |
+          mkdir workspace
+          echo $(( $CIRCLE_BUILD_NUM + 1000 )) > workspace/build_id
+          cat workspace/build_id
       - persist_to_workspace:
-          root: ~/
+          root: workspace
           paths:
-            - artifacts
-      - store_artifacts:
-          path: ~/artifacts
-      - go/save-cache
-
-  publish:
-    docker:
-      - image: cibuilds/github:0.13.0
+            - build_id
+  watch:
+    executor: linuxgo
     steps:
-      - attach_workspace:
-          at: ~/
+      - buildevents/watch_build_and_finish
+
+  test:
+    executor: linuxgo
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - buildevents/berun:
+                bename: go_test
+                becommand: go test -v ./...
+  build_bins:
+    executor: linuxgo
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - go-build:
+                os: linux
+                arch: "386"
+            - go-build:
+                os: linux
+                arch: amd64
+            - go-build:
+                os: darwin
+                arch: amd64
+            - go-build:
+                os: linux
+                arch: arm64
+
+            - run: mkdir -v artifacts; cp -v $GOPATH/bin/rdslogs-* artifacts/
+
+            - run: echo "size=$(du -sb artifacts | cut -f 1)" >> $BASH_ENV
+            - buildevents/add_context:
+                field_name: artifacts_size_bytes
+                field_value: $size
+
+            - persist_to_workspace:
+                root: artifacts
+                paths:
+                  - rdslogs-*
+            - store_artifacts:
+                path: artifacts/
+
+  publish_github:
+    docker:
+      - image: cibuilds/github:0.12.2
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - attach_workspace:
+                at: artifacts
+            - run:
+                name: "Publish Release on GitHub"
+                command: |
+                  echo "about to publish to tag ${CIRCLE_TAG}"
+                  ls -l *
+                  ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts
+
+  build_docker:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - run: go install github.com/google/ko@latest
+      - checkout
+      - setup_remote_docker
       - run:
-          name: "Publish Release on GitHub"
+          name: build docker images and publish locally
+          command: ./build-docker.sh
+
+  publish_docker:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - run: go install github.com/google/ko@latest
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: build docker images and publish to Docker Hub
+          environment:
+            KO_DOCKER_REPO: honeycombio
           command: |
-            echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ~/artifacts/*
-            ghr -draft -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+            ./build-docker.sh
 
 workflows:
   build:
     jobs:
-      - test:
+      - setup:
           filters:
             tags:
               only: /.*/
-      - build:
-          requires:
-            - test
-          filters:
-            tags:
-              only: /.*/
-      - publish:
+      - watch:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
+      - test:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+      - build_bins:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+      - build_docker:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+      - publish_github:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_bins
+            - build_docker
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_docker:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_bins
+            - build_docker
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm
-      - run: echo "finished builds" && find ~/artifacts -ls
+      - run: echo "finished building packages" && find ~/packages -ls
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           GOARCH=<< parameters.arch >> \
           CGO_ENABLED=0 \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
-          -o $GOPATH/bin/rdslogs-<< parameters.os >>-<< parameters.arch >> \
+          -o ~/artifacts/rdslogs-<< parameters.os >>-<< parameters.arch >> \
           .
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,13 @@ executors:
 platform_matrix: &platform_matrix
   matrix:
     parameters:
-      os: &oses ["linux", "darwin"] # <-- "windows" in the future!
+      os: &oses ["linux", "darwin"]
       arch: &arches ["amd64", "arm64", "arm", "386"]
     exclude:
       - os: darwin
         arch: arm
       - os: darwin
         arch: "386"
-    # exclude: # And when Windows comes, we'll need to exclude the Win+arm64 combo:
-    #   - os: "windows"
-    #     arch: "arm64"
 
 jobs:
   test:
@@ -58,7 +55,9 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - artifacts
+            - binaries/rdslogs-<< parameters.os >>-<< parameters.arch >>
+      - store_artifacts:
+          path: binaries/rdslogs-<< parameters.os >>-<< parameters.arch >>
 
   ## We only have to build packages for linux, so we iterate architectures and build rpm and deb for each.
   build_packages:
@@ -79,9 +78,22 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - artifacts
+            - packages/<< parameters.arch >>/*
       - store_artifacts:
-          path: ~/artifacts
+          path: ~/packages/<< parameters.arch >>
+
+  consolidate_artifacts:
+    docker:
+    - image: cimg/go:1.18
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: cp -R ~/binaries ~/artifacts
+      - run: find ~/packages -type f -print0 |xargs -0 -I {} cp {} ~/artifacts
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
 
   publish_github:
     docker:
@@ -170,10 +182,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - consolidate_artifacts:
+          requires:
+            - build_packages
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build_packages
+            - consolidate_artifacts
           filters:
             tags:
               only: /^v.*/
@@ -182,7 +200,7 @@ workflows:
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build_packages
+            - consolidate_artifacts
           filters:
             tags:
               only: /^v.*/
@@ -191,7 +209,6 @@ workflows:
       - publish_docker:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build_bins
             - build_docker
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,102 @@
+version: 2.1
+
+orbs:
+  go: circleci/go@1.7.0
+
+commands:
+  go-build:
+    parameters:
+      os:
+        description: Target operating system
+        type: enum
+        enum: [ "linux", "darwin" ]
+        default: "linux"
+      arch:
+        description: Target architecture
+        type: enum
+        enum: [ "amd64", "arm64" ]
+        default: "amd64"
+      dir:
+        description: Output directory
+        type: string
+        default: "~/artifacts"
+    steps:
+      - run: |
+          GOOS=<< parameters.os >> \
+          GOARCH=<< parameters.arch >> \
+          go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
+          -o << parameters.dir >>/rdslogs-<< parameters.os >>-<< parameters.arch >> \
+          ./...
+
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - go/load-cache
+      - go/test:
+          race: true
+          verbose: true
+          covermode: atomic
+      - go/save-cache
+
+  build:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - go/load-cache
+      - run: mkdir -p ~/artifacts
+      - go-build:
+          os: linux
+          arch: amd64
+      - go-build:
+          os: linux
+          arch: arm64
+      - go-build:
+          os: darwin
+          arch: amd64
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
+      - go/save-cache
+
+  publish:
+    docker:
+      - image: cibuilds/github:0.13.0
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+            ghr -draft -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
+workflows:
+  build:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /.*/
+      - publish:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,117 +1,114 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.8
   aws-cli: circleci/aws-cli@2.0.3
+  docker: circleci/docker@1.3.0
 
 executors:
-  linuxgo:
+  pkg:
+    ## executor with fpm and npmbuild
+    docker:
+      - image: alanfranz/fpm-within-docker:centos-8
+
+platform_matrix: &platform_matrix
+  matrix:
+    parameters:
+      os: &oses ["linux", "darwin"] # <-- "windows" in the future!
+      arch: &arches ["amd64", "arm64", "arm", "386"]
+    exclude:
+      - os: darwin
+        arch: arm
+      - os: darwin
+        arch: "386"
+    # exclude: # And when Windows comes, we'll need to exclude the Win+arm64 combo:
+    #   - os: "windows"
+    #     arch: "arm64"
+
+jobs:
+  test:
     docker:
       - image: cimg/go:1.18
-        environment:
-          GO111MODULE: "on"
-  pkg:
-    ## executor with ruby for installing fpm and building packages
-    docker:
-      - image: cimg/ruby:latest
+    steps:
+      - checkout
+      - run: go test --timeout 10s -v ./...
 
-commands:
-  go-build:
+  build_bins:
+    docker:
+      - image: cimg/go:1.18
     parameters:
       os:
         description: Target operating system
         type: enum
-        enum: ["linux", "darwin"]
+        enum: *oses
         default: "linux"
       arch:
         description: Target architecture
         type: enum
-        enum: ["386", "amd64", "arm64"]
+        enum: *arches
         default: "amd64"
     steps:
+      - checkout
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
           CGO_ENABLED=0 \
-          buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_build -- \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
           -o $GOPATH/bin/rdslogs-<< parameters.os >>-<< parameters.arch >> \
-          ./...
-
-jobs:
-  setup:
-    executor: linuxgo
-    steps:
-      - buildevents/start_trace
-      - run: |
-          mkdir workspace
-          echo $(( $CIRCLE_BUILD_NUM + 1000 )) > workspace/build_id
-          cat workspace/build_id
+          .
       - persist_to_workspace:
-          root: workspace
+          root: ~/
           paths:
-            - build_id
-  watch:
-    executor: linuxgo
+            - artifacts
+
+  ## We only have to build packages for linux, so we iterate architectures and build rpm and deb for each.
+  build_packages:
+    executor: pkg
+    parameters:
+      arch:
+        description: Target architecture
+        type: enum
+        enum: *arches
+        default: "amd64"
     steps:
-      - buildevents/watch_build_and_finish
-
-  test:
-    executor: linuxgo
-    steps:
-      - buildevents/with_job_span:
-          steps:
-            - checkout
-            - buildevents/berun:
-                bename: go_test
-                becommand: go test -v ./...
-  build_bins:
-    executor: linuxgo
-    steps:
-      - buildevents/with_job_span:
-          steps:
-            - checkout
-            - go-build:
-                os: linux
-                arch: "386"
-            - go-build:
-                os: linux
-                arch: amd64
-            - go-build:
-                os: darwin
-                arch: amd64
-            - go-build:
-                os: linux
-                arch: arm64
-
-            - run: mkdir -v artifacts; cp -v $GOPATH/bin/rdslogs-* artifacts/
-
-            - run: echo "size=$(du -sb artifacts | cut -f 1)" >> $BASH_ENV
-            - buildevents/add_context:
-                field_name: artifacts_size_bytes
-                field_value: $size
-
-            - persist_to_workspace:
-                root: artifacts
-                paths:
-                  - rdslogs-*
-            - store_artifacts:
-                path: artifacts/
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm
+      - run: echo "finished builds" && find ~/artifacts -ls
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
 
   publish_github:
     docker:
-      - image: cibuilds/github:0.12.2
+      - image: cibuilds/github:0.13.0
     steps:
-      - buildevents/with_job_span:
-          steps:
-            - attach_workspace:
-                at: artifacts
-            - run:
-                name: "Publish Release on GitHub"
-                command: |
-                  echo "about to publish to tag ${CIRCLE_TAG}"
-                  ls -l *
-                  ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
+  publish_s3:
+    executor: aws-cli/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - aws-cli/install
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+          name: sync_s3_artifacts
+          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/rdslogs/${CIRCLE_TAG}/
 
   build_docker:
     docker:
@@ -140,46 +137,52 @@ jobs:
             ./build-docker.sh
 
 workflows:
+  version: 2
   build:
     jobs:
-      - setup:
-          filters:
-            tags:
-              only: /.*/
-      - watch:
-          context: Honeycomb Secrets for Public Repos
-          requires:
-            - setup
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore:
-                - /pull\/.*/
-                - /dependabot\/.*/
       - test:
-          requires:
-            - setup
           filters:
             tags:
               only: /.*/
       - build_bins:
+          <<: *platform_matrix
           requires:
-            - setup
+            - test
           filters:
             tags:
               only: /.*/
+      - build_packages:
+          matrix:
+            parameters:
+              arch: *arches
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_bins
+          filters:
+            tags:
+              # allow tags that start with t so we can test builds without publishing
+              only: /^[vt].*/
+            branches:
+              ignore: /.*/
       - build_docker:
           requires:
-            - setup
+            - test
           filters:
             tags:
               only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build_bins
-            - build_docker
+            - build_packages
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_s3:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_packages
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           GOARCH=<< parameters.arch >> \
           CGO_ENABLED=0 \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
-          -o ~/artifacts/rdslogs-<< parameters.os >>-<< parameters.arch >> \
+          -o ~/binaries/rdslogs-<< parameters.os >>-<< parameters.arch >> \
           .
       - persist_to_workspace:
           root: ~/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+# Releasing Process
+
+1. Add release entry to [changelog](./CHANGELOG.md)
+3. Open a PR with the above, and merge that into main
+4. Create new tag on merged commit with the new version (e.g. `v0.2.1`)
+5. Push the tag upstream (this will kick off the release pipeline in CI)
+6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+7. Update [public docs](https://github.com/honeycombio/docs/blob/main/scripts)

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,24 @@
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+TAGS="latest"
+VERSION="dev"
+if [[ -n ${CIRCLE_TAG:-} ]]; then
+    # trim 'v' prefix if present
+    VERSION=${CIRCLE_TAG#"v"}
+    # append version to image tags
+    TAGS+=",$VERSION"
+fi
+
+unset GOOS
+unset GOARCH
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
+export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
+export SOURCE_DATE_EPOCH=$(date +%s)
+# shellcheck disable=SC2086
+ko publish \
+  --tags "${TAGS}" \
+  --base-import-paths \
+  --platform "linux/amd64,linux/arm64" \
+  .

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -4,11 +4,11 @@
 set -e
 
 function usage() {
-    echo "Usage: build-pkg.sh -v <version> -t <package_type>"
+    echo "Usage: build-pkg.sh -v <version> -t <package_type> -m arch"
     exit 2
 }
 
-while getopts "v:t:" opt; do
+while getopts "v:t:m:" opt; do
     case "$opt" in
     v)
         version=$OPTARG
@@ -16,20 +16,24 @@ while getopts "v:t:" opt; do
     t)
         pkg_type=$OPTARG
         ;;
+    m)
+        arch=$OPTARG
+        ;;
     esac
 done
 
-if [ -z "$version" ] || [ -z "$pkg_type" ]; then
+if [ -z "$version" ] || [ -z "$pkg_type" ] || [ -z "$arch" ]; then
     usage
 fi
 
 fpm -s dir -n rdslogs \
-    -m "Honeycomb <team@honeycomb.io>" \
-    -p $GOPATH/bin \
+    -m "Honeycomb <solutions@honeycomb.io>" \
+    -p ~/artifacts \
     -v $version \
     -t $pkg_type \
+    -a $arch \
     --pre-install=./preinstall \
-    $GOPATH/bin/rdslogs=/usr/bin/rdslogs \
+    ~/artifacts/rdslogs-linux-${arch}=/usr/bin/rdslogs \
     ./rdslogs.upstart=/etc/init/rdslogs.conf \
     ./rdslogs.service=/lib/systemd/system/rdslogs.service \
     ./rdslogs.conf=/etc/rdslogs/rdslogs.conf \

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -26,14 +26,16 @@ if [ -z "$version" ] || [ -z "$pkg_type" ] || [ -z "$arch" ]; then
     usage
 fi
 
+PACKAGE_DIR=~/packages/${arch}
+mkdir -p ${PACKAGE_DIR}
 fpm -s dir -n rdslogs \
     -m "Honeycomb <solutions@honeycomb.io>" \
-    -p ~/artifacts \
+    -p ${PACKAGE_DIR} \
     -v $version \
     -t $pkg_type \
     -a $arch \
     --pre-install=./preinstall \
-    ~/artifacts/rdslogs-linux-${arch}=/usr/bin/rdslogs \
+    ~/binaries/rdslogs-linux-${arch}=/usr/bin/rdslogs \
     ./rdslogs.upstart=/etc/init/rdslogs.conf \
     ./rdslogs.service=/lib/systemd/system/rdslogs.service \
     ./rdslogs.conf=/etc/rdslogs/rdslogs.conf \

--- a/rdslogs.conf
+++ b/rdslogs.conf
@@ -1,0 +1,58 @@
+[Application Options]
+; AWS region to use
+; Region = us-east-1
+
+; RDS instance identifier
+; InstanceIdentifier =
+
+; RDS database type. Accepted values are mysql and postgresql.
+; DBType = mysql
+
+; Log file type. Accepted values are query and audit. Audit is currently only supported for mysql.
+; LogType = query
+
+; RDS log file to retrieve
+; LogFile =
+
+; Download old logs instead of tailing the current log
+; Download = false
+
+; directory in to which log files are downloaded
+; DownloadDir = ./
+
+; number of lines to request at a time from AWS. Larger number will be more efficient, smaller number will allow for longer lines
+; NumLines = 10000
+
+; how many seconds to pause when rate limited by AWS.
+; BackoffTimer = 5
+
+; output for the logs: stdout or honeycomb
+; Output = stdout
+
+; Team write key, when output is honeycomb
+; WriteKey =
+
+; Name of the dataset, when output is honeycomb
+; Dataset =
+
+; Hostname for the Honeycomb API server
+; APIHost = https://api.honeycomb.io/
+
+; Replaces the query field with a one-way hash of the contents
+; ScrubQuery = false
+
+; Only send 1 / N log lines
+; SampleRate = 1
+
+; Extra fields to send in request, in the style of "field:value"
+; AddFields =
+
+; Number of parsers to spin up. Currently only supported for the mysql parser.
+; NumParsers = 4
+
+; Output the current version and exit
+; Version = false
+
+; turn on debugging output
+; Debug = false
+


### PR DESCRIPTION
## Which problem is this PR solving?
- Adds CircleCI configuration to build and test rdslogs and manage the release process to Github. Also includes updating the docker image used to create the binaries to golang 1.18 which includes an updated OpenSSL to resolve CVE (modified from the one in honeymarker).
- Adds a default configuration file (ancient builds for a single platform used to just generate this on the fly, but that's trickier in a multi-platform world, so we just generated it locally and committed it).
- Update the build_pkg.sh script (modified from the one in honeymarker).
- Add a build_docker.sh script (from the one in honeymarker).

- Closes #41
- Closes #46

## Short description of the changes
- Add CircleCI configuration to build, test and release