### PR TITLE
Use session.NewSession when creating AWS CLI instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,9 +46,13 @@ func main() {
 		}
 	}()
 
+	session, err := session.NewSession()
+	if err != nil {
+		log.Fatal(err)
+	}
 	c := &cli.CLI{
 		Options: options,
-		RDS: rds.New(session.New(), &aws.Config{
+		RDS: rds.New(session, &aws.Config{
 			Region: aws.String(options.Region),
 		}),
 		Abort: abort,


### PR DESCRIPTION
### Which problem is this PR solving?
When creating the AWS CLI instance used to retrieve RDS logs, there are a couple of different ways to authenticate the client. A newer way to authenticate, AWS web tokens, request the client create a session using `session.NewSession` to allow it to read the appropriate credentials.

More details can be seen here:
- https://github.com/aws/aws-sdk-go/issues/3218

Fixes #48 

### Short description of the changes
- update client creation to use `session.NewSession` and log if an error is returned

NOTE: CircleCI build is failing because the circle CI config is missing in this PR. It will be added in the below PR:
- #47