### PR TITLE
Prep for release 1.135.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# rdslogs changelog
+
+## [1.135.0] - 2022-05-17
+
+### Fixes
+
+- Use session.NewSession when creating AWS CLI instance (#50)  | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+
+### Maintenance
+
+- Modernize the CI pipeline (#37 - #49)  | Many participants
+


### PR DESCRIPTION
This is the first release in almost a year; it's also likely to be the last, as the project is being sunset (#51). The CI has been completely renovated to conform to current Honeycomb standards, and a changelog has been added for the first time. 