### PR TITLE
Kent.prep 1.135.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rdslogs changelog
 
+## [1.135.1] - 2022-07-20
+
+### Maintenance
+
+- Re-release to fix an OpenSSL CVE | [@kentquirk](https://github.com/kentquirk)
+
 ## [1.135.0] - 2022-05-17
 
 ### Fixes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,4 +5,3 @@
 4. Create new tag on merged commit with the new version (e.g. `v0.2.1`)
 5. Push the tag upstream (this will kick off the release pipeline in CI)
 6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
-7. Update [public docs](https://github.com/honeycombio/docs/blob/main/scripts)


### PR DESCRIPTION
Releasing no longer requires updating docs, so I took that line out of the RELEASING file.